### PR TITLE
fix: simulations list and running info not working

### DIFF
--- a/apps/client/src/components/simulations/new/form-acpype/index.tsx
+++ b/apps/client/src/components/simulations/new/form-acpype/index.tsx
@@ -76,7 +76,7 @@ export function FormACPYPE({ user }: PropsWithUser) {
                 }
               }
             )
-            .then(() => router.push("/dynamic/running"))
+            .then(() => router.push("/simulations/running"))
             .catch(() => alert("not running"));
         } else if (data.status === "commands") {
           const link = document.createElement("a");

--- a/apps/client/src/components/simulations/new/form-apo/index.tsx
+++ b/apps/client/src/components/simulations/new/form-apo/index.tsx
@@ -76,7 +76,7 @@ export function FormAPO({ user }: PropsWithUser) {
                 }
               }
             )
-            .then(() => router.push("/dynamic/running"))
+            .then(() => router.push("/simulations/running"))
             .catch(() => alert("not running"));
         } else if (data.status === "commands") {
           const link = document.createElement("a");

--- a/apps/client/src/components/simulations/new/form-prodrg/index.tsx
+++ b/apps/client/src/components/simulations/new/form-prodrg/index.tsx
@@ -76,7 +76,7 @@ export function FormPRODRG({ user }: PropsWithUser) {
                 }
               }
             )
-            .then(() => router.push("/dynamic/running"))
+            .then(() => router.push("/simulations/running"))
             .catch(() => alert("not running"));
         } else if (data.status === "commands") {
           const link = document.createElement("a");

--- a/apps/server/server/resources/user_dynamics/__init__.py
+++ b/apps/server/server/resources/user_dynamics/__init__.py
@@ -23,7 +23,7 @@ class UserDynamics(Resource):
                 running_dynamic = f.readline()
 
         if not os.path.exists(file_dynamics_list):
-            return {"status": "no-dynamics"}
+            return {"status": "no-simulations"}
 
         with open(file_dynamics_list, "r") as f:
             dynamics_list = f.readlines()
@@ -73,4 +73,4 @@ class UserDynamics(Resource):
 
             returnable_dynamics_list.append(dynamic_data)
 
-        return {"status": "listed", "dynamics": returnable_dynamics_list[::-1]}
+        return {"status": "has-simulations", "simulations": returnable_dynamics_list[::-1]}


### PR DESCRIPTION
User simulations list and running page won't work as expected due to missing renamings.