### PR TITLE
Fix Typo in start shell script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-conda actitave visualdynamics
+conda activate visualdynamics
 pm2 start ecosystem.config.js
+


### PR DESCRIPTION
Typo:
conda **actitave** visualdynamics

Fixed to:
conda **activate** visualdynamics